### PR TITLE
Add CV and website todo list (HCIC talks, Curiosity Desk)

### DIFF
--- a/cv-website-todos.md
+++ b/cv-website-todos.md
@@ -30,6 +30,13 @@ Track missing entries discussed in Mar 2026. Check off items as completed.
 
 ---
 
+## CV sync & publications blurb
+
+- [ ] **Merge 2-pager changes into `cv.tex`** — Diff `cv2page.tex` against `cv.tex` and port any updates that exist only on the two-pager back into the main CV (e.g. service structure, talk lines, formatting tweaks). Resolve conflicts deliberately rather than overwriting wholesale.
+- [ ] **Add ACL to conference selectivity text** — In `\section*{All Publications}` intro (currently “Top-tier ACM and AAAI conferences… e.g., CHI, CSCW, UIST, IUI, HRI, and ICWSM”), add **ACL** to the list and/or prose where it fits (you have ACL workshop papers on the CV). Update `cv2page.tex` too if that blurb should stay in sync.
+
+---
+
 ## Curiosity Desk appearance
 
 - [ ] **Gather details** — Episode title, air/date (or taping date), role (guest, expert, etc.), and link (WGBH / YouTube / station page if available).
@@ -55,5 +62,6 @@ Track missing entries discussed in Mar 2026. Check off items as completed.
 - [ ] CV lists all HCIC invited talks (including 2026) with correct titles and years.
 - [ ] **Trustworthy AI for Code Industry Roundtable** appears with full title (not just “AI for Code”).
 - [ ] CV lists ISF grant review for 2026 (and prior year(s) if applicable).
+- [ ] `cv.tex` reflects merged updates from `cv2page.tex`; publications blurb mentions ACL.
 - [ ] CV lists Curiosity Desk appearance.
 - [ ] Live website reflects Curiosity Desk (and HCIC talks if desired).

--- a/cv-website-todos.md
+++ b/cv-website-todos.md
@@ -1,0 +1,42 @@
+# CV & website update todos
+
+Track missing entries discussed in Mar 2026. Check off items as completed.
+
+---
+
+## HCIC invited talks (CV)
+
+- [ ] **Gather talk history** — Search email (Gmail: `HCIC OR "Human-Computer Interaction Consortium"`) and/or calendar for invitations, confirmations, and programs. Record for each year: date/year, exact title, and role (invited talk vs. keynote, etc.).
+- [ ] **Confirm 2026 talk** — Verify spelling and title for *Design for Disobedience* (or official program title) at HCIC 2026.
+- [ ] **Add entries to `cv.tex`** — Under `\section*{Symposium Talks}` (or `\section*{Invited Keynote Talks}` if that matches how you classify HCIC), add one `\years{YYYY}...` line per talk with title and `\hfill HCIC` (or `Human-Computer Interaction Consortium` for consistency with the 2024 organizing entry).
+- [ ] **Mirror in `cv2page.tex`** — If the two-page CV is still in use, add the same HCIC talk lines there (section is `\section*{Conference Symposium Talks}`).
+- [ ] **Rebuild PDF** — Recompile `cv.tex` and update `Academic_CV.pdf` if that file is checked into the repo / deployed from here.
+- [ ] **Quick audit** — Ensure HCIC *organizing* (2024 “History and Future of HCI”) stays under Service → Small Conference and Workshop Organizing Committees and is not confused with talk entries.
+
+---
+
+## Curiosity Desk appearance
+
+- [ ] **Gather details** — Episode title, air/date (or taping date), role (guest, expert, etc.), and link (WGBH / YouTube / station page if available).
+- [ ] **Add to `cv.tex`** — Pick section (likely `\section*{Selected press}` or `\section*{Selected Outreach}`; add a new subsection only if nothing fits). Use same `\years{}` / `\hfill` format as neighboring lines.
+- [ ] **Mirror in `cv2page.tex`** — If applicable.
+- [ ] **Rebuild PDF** — Recompile and refresh `Academic_CV.pdf` if maintained here.
+
+---
+
+## Personal / lab website
+
+> Website source is **not** in this repo (lab site: `https://glassmanlab.seas.harvard.edu/`). Update wherever that site is built (separate repo, CMS, or static site).
+
+- [ ] **Locate website source** — Find repo or editor for faculty page / news / media section.
+- [ ] **Add Curiosity Desk** — List appearance with date, title, and link on an appropriate page (e.g. media, news, or talks/outreach).
+- [ ] **Optional: add HCIC talks** — If the site lists invited talks, add the same HCIC history (and 2026 talk) for consistency with the CV.
+- [ ] **Publish / deploy** — Push changes and confirm the live page.
+
+---
+
+## Done when
+
+- [ ] CV lists all HCIC invited talks (including 2026) with correct titles and years.
+- [ ] CV lists Curiosity Desk appearance.
+- [ ] Live website reflects Curiosity Desk (and HCIC talks if desired).

--- a/cv-website-todos.md
+++ b/cv-website-todos.md
@@ -15,6 +15,12 @@ Track missing entries discussed in Mar 2026. Check off items as completed.
 
 ---
 
+## CV title audit: Trustworthy AI for Code
+
+- [ ] **Verify full roundtable title** — Confirm `\section*{Invited Keynote Talks}` lists **Trustworthy AI for Code Industry Roundtable** (2026, IBM NYC/Columbia), not the shortened **AI for Code**. As of last check, `cv.tex` has the full title under Invited Keynote Talks; **AI for Code** (2024, Google DeepMind) is a separate entry under Invited Seminar Talks — make sure they stay distinct and the roundtable is not missing or mislabeled on either CV file or the PDF.
+
+---
+
 ## Curiosity Desk appearance
 
 - [ ] **Gather details** — Episode title, air/date (or taping date), role (guest, expert, etc.), and link (WGBH / YouTube / station page if available).
@@ -38,5 +44,6 @@ Track missing entries discussed in Mar 2026. Check off items as completed.
 ## Done when
 
 - [ ] CV lists all HCIC invited talks (including 2026) with correct titles and years.
+- [ ] **Trustworthy AI for Code Industry Roundtable** appears with full title (not just “AI for Code”).
 - [ ] CV lists Curiosity Desk appearance.
 - [ ] Live website reflects Curiosity Desk (and HCIC talks if desired).

--- a/cv-website-todos.md
+++ b/cv-website-todos.md
@@ -21,6 +21,15 @@ Track missing entries discussed in Mar 2026. Check off items as completed.
 
 ---
 
+## ISF grant review (CV)
+
+- [ ] **Confirm prior ISF entry** — Check whether ISF (Israel Science Foundation?) review appears in an older CV version or email; user recalled reviewing “again” in 2026, so note any earlier year(s) to list together if appropriate.
+- [ ] **Add to `cv.tex`** — Under `\section*{Service}` → `\subsection*{External Reviewing}` → *Grants*, add e.g. `\years{2026}Grant review\hfill ISF` (or expand an existing ISF line to `\years{YYYY, 2026}` if a prior year is found).
+- [ ] **Mirror in `cv2page.tex`** — If applicable.
+- [ ] **Rebuild PDF** — Recompile and refresh `Academic_CV.pdf` if maintained here.
+
+---
+
 ## Curiosity Desk appearance
 
 - [ ] **Gather details** — Episode title, air/date (or taping date), role (guest, expert, etc.), and link (WGBH / YouTube / station page if available).
@@ -45,5 +54,6 @@ Track missing entries discussed in Mar 2026. Check off items as completed.
 
 - [ ] CV lists all HCIC invited talks (including 2026) with correct titles and years.
 - [ ] **Trustworthy AI for Code Industry Roundtable** appears with full title (not just “AI for Code”).
+- [ ] CV lists ISF grant review for 2026 (and prior year(s) if applicable).
 - [ ] CV lists Curiosity Desk appearance.
 - [ ] Live website reflects Curiosity Desk (and HCIC talks if desired).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `cv-website-todos.md` to track outstanding updates:

- Backfill missing HCIC invited talks on the CV (including 2026 *Design for Disobedience*), with steps to gather titles/years from email
- Add Curiosity Desk appearance to the CV
- Add Curiosity Desk (and optionally HCIC talks) to the lab website (noted as out-of-repo)

No CV content changes in this PR—checklist only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8cd62467-a8f3-4ff5-a9ed-54383c04aed6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8cd62467-a8f3-4ff5-a9ed-54383c04aed6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

